### PR TITLE
Add command to synchronize Capact CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ npm run build
 
 It can be served using any static contents hosting service. You can use `npm run serve` command to set up a development static server.
 
-### Synchronize documentation
+### Synchronize CLI documentation
 
-Files in the `docs` directory are synchronized from `capact` repository. To synchronize them, run:
+The documents that describe Capact CLI commands reside in the `capact` repository. To synchronize them, run:
 
 ```bash
-npm run sync-docs
+npm run sync-cli-docs
 ```
 
-> **NOTE:** The script assumes that the `capact` repository is located on the `../capact` path relative to the root of the directory.
+> **NOTE:** The script assumes that the `capact` repository is located under the `../capact` path relative to the root of the directory.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "lint": "eslint . --ext .json,.js,.jsx,.ts,.tsx",
-    "sync-docs": "rm -rf ./docs; rsync -av --progress ../capact/docs $(pwd) --exclude internal"
+    "delete-cli-docs": "find ./docs/cli/commands -type f ! -name '_category_.json' -delete",
+    "sync-cli-docs": "npm run delete-cli-docs; rsync -av --progress ../capact/cmd/cli/docs/* $(pwd)/docs/cli/commands"
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.0",


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Add command to synchronize Capact CLI docs
- Remove command for manual synchronization of all docs (as after merge of this PR the `main` branch history will be rewritten with full docs)

## Related issue(s)

See https://github.com/capactio/capact/issues/333
