### PR TITLE
Unify and simplify our `capact login` approach

### DIFF
--- a/docs/cli/getting-started.mdx
+++ b/docs/cli/getting-started.mdx
@@ -183,8 +183,20 @@ Run `capact -h` or `capact <command> -h` to see the help output which correspond
 To begin working with Capact using the `capact` CLI, start with log in into a given cluster:
 
 ```shell
+# start interactive setup
 capact login
+
+# provide all information from command line
+capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
 ```
+
+> **NOTE:** If you do not know the authorization details, you can obtain them from the cluster where Capact was installed:
+>
+>    ```bash
+>    export CAPACT_GATEWAY_HOST=$(kubectl -n capact-system get ingress capact-gateway -ojsonpath='{.spec.rules[0].host}')
+>    export CAPACT_GATEWAY_USERNAME=$(kubectl -n capact-system get secret capact-gateway -ogo-template={{.data.username | base64decode }})
+>    export CAPACT_GATEWAY_PASSWORD=$(kubectl -n capact-system get secret capact-gateway -ogo-template='{{.data.password | base64decode}}')
+>    ```
 
 If URL and credentials are valid, the output is:
 

--- a/docs/cli/getting-started.mdx
+++ b/docs/cli/getting-started.mdx
@@ -178,25 +178,22 @@ Run `capact -h` or `capact <command> -h` to see the help output which correspond
 
 ## First use
 
-> **NOTE:** The `capact action watch` command calls the Kubernetes API directly. If you want to use this command, kubeconfig has to be configured with the same cluster as the one which the Gateway points to.
-
-To begin working with Capact using the `capact` CLI, start with log in into a given cluster:
+To begin working with Capact using the `capact` CLI, start with log in interactively into a given cluster:
 
 ```shell
 # start interactive setup
 capact login
+```
+
+If you do not know the authorization details, you can obtain them from the cluster where Capact was installed:
+```bash
+export CAPACT_GATEWAY_HOST=$(kubectl -n capact-system get ingress capact-gateway -ojsonpath='{.spec.rules[0].host}')
+export CAPACT_GATEWAY_USERNAME=$(kubectl -n capact-system get secret capact-gateway -ogo-template='{{.data.username | base64decode }}')
+export CAPACT_GATEWAY_PASSWORD=$(kubectl -n capact-system get secret capact-gateway -ogo-template='{{.data.password | base64decode}}')
 
 # provide all information from command line
 capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
 ```
-
-> **NOTE:** If you do not know the authorization details, you can obtain them from the cluster where Capact was installed:
->
->    ```bash
->    export CAPACT_GATEWAY_HOST=$(kubectl -n capact-system get ingress capact-gateway -ojsonpath='{.spec.rules[0].host}')
->    export CAPACT_GATEWAY_USERNAME=$(kubectl -n capact-system get secret capact-gateway -ogo-template={{.data.username | base64decode }})
->    export CAPACT_GATEWAY_PASSWORD=$(kubectl -n capact-system get secret capact-gateway -ogo-template='{{.data.password | base64decode}}')
->    ```
 
 If URL and credentials are valid, the output is:
 
@@ -209,6 +206,12 @@ Now you are ready to interact with the cluster via CLI. For example, fetch all a
 ```shell
 capact hub interfaces get
 ```
+
+> **NOTE:** The `capact action watch` command calls the Kubernetes API directly. If you want to use this command, kubeconfig has to be configured with the same cluster as the one which the Gateway points to.
+
+### Log into multiple servers
+
+> **NOTE:** We do not support setting kubeconfig per server. You need to manage it manually by changing the kubeconfig context, for example via `kubectl`.
 
 You can log into multiple clusters. To check in which cluster you already logged in, run:
 

--- a/docs/example/mattermost-installation.md
+++ b/docs/example/mattermost-installation.md
@@ -52,20 +52,7 @@ As a result, all external solutions, such as Cloud SQL, have a lower priority, a
     kubectl create namespace $NAMESPACE
     ```
  
-1. Login to Capact in the CLI:
-
-    To obtain the Gateway URL and authorization information, run:
-    
-    ```bash
-    export CAPACT_GATEWAY_HOST=$(kubectl -n capact-system get ingress capact-gateway -ojsonpath='{.spec.rules[0].host}')
-    export CAPACT_GATEWAY_USERNAME=$(kubectl -n capact-system get secret capact-gateway -ogo-template={{.data.username | base64decode }})
-    export CAPACT_GATEWAY_PASSWORD=$(kubectl -n capact-system get secret capact-gateway -ogo-template='{{.data.password | base64decode}}')
-    ```
-
-    Login using Capact CLI:
-    ```bash
-    capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
-    ```
+1. [Setup Capact CLI](../cli/getting-started.mdx#first-use)
 
 1. List all Interfaces:
 

--- a/docs/example/mattermost-installation.md
+++ b/docs/example/mattermost-installation.md
@@ -58,8 +58,8 @@ As a result, all external solutions, such as Cloud SQL, have a lower priority, a
     
     ```bash
     export CAPACT_GATEWAY_HOST=$(kubectl -n capact-system get ingress capact-gateway -ojsonpath='{.spec.rules[0].host}')
-    export CAPACT_GATEWAY_USERNAME=$(kubectl -n capact-system get deployment capact-gateway -oyaml | grep -A1 "name: APP_AUTH_USERNAME" | tail -1 | awk -F ' ' '{print $2}')
-    export CAPACT_GATEWAY_PASSWORD=$(kubectl -n capact-system get deployment capact-gateway -oyaml | grep -A1 "name: APP_AUTH_PASSWORD" | tail -1 | awk -F ' ' '{print $2}')
+    export CAPACT_GATEWAY_USERNAME=$(kubectl -n capact-system get secret capact-gateway -ogo-template={{.data.username | base64decode }})
+    export CAPACT_GATEWAY_PASSWORD=$(kubectl -n capact-system get secret capact-gateway -ogo-template='{{.data.password | base64decode}}')
     ```
 
     Login using Capact CLI:

--- a/docs/example/rocketchat-installation.md
+++ b/docs/example/rocketchat-installation.md
@@ -28,22 +28,7 @@ The following tools are required:
 ### Install all RocketChat components in a Kubernetes cluster
 
 
-1. Setup Capact CLI
-
-    To obtain the Gateway URL and password run:
-    
-    ```bash
-    HOST=`kubectl -n capact-system get ingress capact-gateway -o go-template --template="{{ (index .spec.rules 0).host }}"`
-    USERNAME=`helm -n capact-system get values capact --all -o json | jq .global.gateway.auth.username -r`
-    PASSWORD=`helm -n capact-system get values capact --all -o json | jq .global.gateway.auth.password -r`
-    ```
-
-    Configure Capact CLI:
-
-    ```bash
-    capact login "https://${HOST}" -u ${USERNAME} -p ${PASSWORD}
-    capact config set-context https://${HOST}
-    ```
+1. [Setup Capact CLI](../cli/getting-started.mdx#first-use)
 
 1. Make sure to separate workloads
 

--- a/docs/installation/aws-eks.md
+++ b/docs/installation/aws-eks.md
@@ -120,22 +120,7 @@ The bastion host can access the Capact gateway and has Capact CLI preinstalled, 
   ssh -i hack/eks/config/bastion_ssh_private_key ubuntu@$(cat hack/eks/config/bastion_public_ip)
   ```
 
-1. Get the address and credentials to the Capact Gateway:
-  ```bash
-  # get the gateway address
-  export CAPACT_GATEWAY_HOST=$(kubectl -n capact-system get ingress capact-gateway -ojsonpath='{.spec.rules[0].host}')
-
-  # get the gateway username
-  export CAPACT_GATEWAY_USERNAME=$(kubectl -n capact-system get deployment capact-gateway -oyaml | grep -A1 "name: APP_AUTH_USERNAME" | tail -1 | awk -F ' ' '{print $2}')
-
-  # get the gateway password
-  export CAPACT_GATEWAY_PASSWORD=$(kubectl -n capact-system get deployment capact-gateway -oyaml | grep -A1 "name: APP_AUTH_PASSWORD" | tail -1 | awk -F ' ' '{print $2}')
-  ```
-
-1. Login to the cluster:
-  ```bash
-  capact login "https://${CAPACT_GATEWAY_HOST}" -u "${CAPACT_GATEWAY_USERNAME}" -p "${CAPACT_GATEWAY_PASSWORD}"
-  ```
+1. [Setup Capact CLI](../cli/getting-started.mdx#first-use)
 
 1. Verify, if you can query the Capact Gateway and list all Interfaces in the Hub:
   ```bash

--- a/docs/operation/diagnostics.md
+++ b/docs/operation/diagnostics.md
@@ -170,7 +170,6 @@ To check the logs since a given time, use the `--since-time` flag, for example:
 - Check if manifests can be fetched from the Public Hub. Install the latest [stable Capact CLI](../cli/getting-started.mdx), and run:
 
   ```bash
-  capact login # If not logged yet.
   capact hub interfaces search
   ```
 
@@ -228,7 +227,6 @@ To check the logs since a given time, use the `--since-time` flag, for example:
 To check if TypeInstance exists. Install the latest [stable Capact CLI](../cli/getting-started.mdx), and run:
                                
 ```bash
-capact login # If not logged yet.
 capact typeinstance get {TYPE_INSTANCE_ID}
 ```
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Unify our `capact login` approach
- Simplify extracting auth data
   **Previously**
   ```bash
    # Requires Helm and jq CLIs
    helm -n capact-system get values capact --all -o json | jq .global.gateway.auth.password -r
    # Requires kubectl, grep, tail, awk. Password is in plain text as deploy env.
    kubectl -n capact-system get deployment capact-gateway -oyaml | grep -A1 "name: APP_AUTH_PASSWORD" | tail -1 | awk -F ' ' '{print $2}'
   ```
   **Now**
   ```bash
   # Only kubectl. Password is in K8s secret.
   kubectl -n capact-system get secret capact-gateway -ogo-template='{{.data.password | base64decode}}'
   ```
