### PR TITLE
Replace `workflow_dispatch` URL with a valid one

### DIFF
--- a/community/development/ci.md
+++ b/community/development/ci.md
@@ -57,7 +57,7 @@ Steps:
 
 ![Recreate cluster](./assets/ci-recreate-cluster.svg)
 
-The job is defined in the [`.github/workflows/recreate_cluster.yaml`](https://github.com/capactio/capact/tree/main/.github/workflows/recreate_cluster.yaml) file. It is executed on a manual trigger using the [`workflow_dispatch`](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) event. It uses already existing images available in the [ghcr.io/capactio](https://github.com/orgs/capactio/packages?ecosystem=container) registry. As a result, you need to provide a git SHA from which the cluster should be recreated. Optionally, you can override the Docker image version used via the **DOCKER_TAG** parameter.
+The job is defined in the [`.github/workflows/recreate_cluster.yaml`](https://github.com/capactio/capact/tree/main/.github/workflows/recreate_cluster.yaml) file. It is executed on a manual trigger using the [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) event. It uses already existing images available in the [ghcr.io/capactio](https://github.com/orgs/capactio/packages?ecosystem=container) registry. As a result, you need to provide a git SHA from which the cluster should be recreated. Optionally, you can override the Docker image version used via the **DOCKER_TAG** parameter.
 
 > **CAUTION:** This job removes the old GKE cluster.
 


### PR DESCRIPTION
## Description

![Screen Shot 2022-01-25 at 10 35 29](https://user-images.githubusercontent.com/17568639/150950731-691f4f65-0ae5-4170-ae7f-9385252ff19a.png)
_source: https://github.com/capactio/website/runs/4934438298?check_suite_focus=true_

The blog post cannot be found:
![Screen Shot 2022-01-25 at 10 35 49](https://user-images.githubusercontent.com/17568639/150950789-85c98535-fd84-496c-a84c-2be964489c2c.png)

Changes proposed in this pull request:

- Replace `workflow_dispatch` URL with a valid one. It's even better to link to official docs than blog posts.

