### PR TITLE
Update binary location in Google Storage

### DIFF
--- a/docs/cli/getting-started.mdx
+++ b/docs/cli/getting-started.mdx
@@ -15,7 +15,7 @@ Capact has two types of release channels: **Stable** and **Latest**:
 
 ### Stable - from the latest release
 
-Install Capact CLI binary with `curl`:
+Depending on the system, install Capact CLI binary with `homebrew` or `curl`:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -33,26 +33,14 @@ import TabItem from '@theme/TabItem';
 <TabItem value="macos">
 
 ```shell
-curl -Lo capact https://github.com/capactio/capact/releases/download/v0.6.0/capact-darwin-amd64
-```
-
-Copy to binary directory:
-
-```shell
-chmod +x capact && mv capact /usr/local/bin/capact
+brew install capactio/tap/capact
 ```
 
 </TabItem>
 <TabItem value="linux">
 
 ```shell
-curl -Lo capact https://github.com/capactio/capact/releases/download/v0.6.0/capact-linux-amd64
-```
-
-Copy to binary directory:
-
-```shell
-chmod +x capact && mv capact /usr/local/bin/capact
+brew install capactio/tap/capact
 ```
 
 </TabItem>
@@ -60,6 +48,11 @@ chmod +x capact && mv capact /usr/local/bin/capact
 
 ```shell
 curl -Lo capact.exe https://github.com/capactio/capact/releases/download/v0.6.0/capact-windows-amd64.exe
+```
+
+For Windows 10 or newer with Windows Subsystem for Linux (WSL):
+```shell
+brew install capactio/tap/capact
 ```
 
 </TabItem>

--- a/docs/cli/getting-started.mdx
+++ b/docs/cli/getting-started.mdx
@@ -113,7 +113,7 @@ Install Capact CLI binary with `curl`:
 <TabItem value="macos">
 
 ```shell
-curl -Lo capact https://storage.googleapis.com/capactio-binaries/latest/capact-darwin-amd64
+curl -Lo capact https://storage.googleapis.com/capactio-binaries/latest/capact_darwin_amd64/capact
 ```
 
 Copy to binary directory:
@@ -126,7 +126,7 @@ chmod +x capact && mv capact /usr/local/bin/capact
 <TabItem value="linux">
 
 ```shell
-curl -Lo capact https://storage.googleapis.com/capactio-binaries/latest/capact-linux-amd64
+curl -Lo capact https://storage.googleapis.com/capactio-binaries/latest/capact_linux_amd64/capact
 ```
 
 
@@ -140,9 +140,8 @@ chmod +x capact && mv capact /usr/local/bin/capact
 <TabItem value="windows">
 
 ```shell
-curl -Lo capact https://storage.googleapis.com/capactio-binaries/latest/capact-windows-amd64.exe
+curl -Lo capact https://storage.googleapis.com/capactio-binaries/latest/capact_windows_amd64/capact.exe
 ```
-
 </TabItem>
 <TabItem value="docker">
 
@@ -168,7 +167,7 @@ docker run --rm \
 To install a different release version, change the path to point to the desired version and architecture:
 
 ```shell
-curl -Lo capact https://storage.googleapis.com/capactio-binaries/latest/capact-$OS-$ARCH
+curl -Lo capact https://storage.googleapis.com/capactio-binaries/latest/capact_$OS_$ARCH/capact
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- update `capact` binary location in Google Storage

After adding support of `brew`, there was a change of localization of capact binaries. This PR mitigates that. 

## Related issue(s)
- https://github.com/capactio/capact/issues/587
